### PR TITLE
Update docker-compose.yml to replace unsupported marathon version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ slave:
     - /var/run/docker.sock:/var/run/docker.sock
 
 marathon:
-  image: mesosphere/marathon:v1.3.0-RC6
+  image: mesosphere/marathon:v1.3.3
   net: host
   environment:
     - MARATHON_HOSTNAME=127.0.0.1


### PR DESCRIPTION
1.3.0 RC is no longer available on docker hub. Replacing with 1.3.3 (latest release of 1.3 version)
